### PR TITLE
Cookie db base domain deprecation

### DIFF
--- a/ES_templates_dumpzilla/cookies.json
+++ b/ES_templates_dumpzilla/cookies.json
@@ -47,11 +47,7 @@
 	  "8-Secure" : {
 	     "index" : "not_analyzed",
 	     "type" : "string"
-	   },      
-	  "0-Domain" : {
-             "index" : "not_analyzed",
-             "type" : "string"
-          },
+	   },
 	  "9-HttpOnly" : {
 	    "index" : "not_analyzed",
             "type" : "string"

--- a/dumpzilla.py
+++ b/dumpzilla.py
@@ -328,8 +328,8 @@ class Dumpzilla():
           if value == header:
               return lz4.block.decompress(file.read())
           file.seek(0)
-            
-        
+
+
 
         return None
 
@@ -654,27 +654,26 @@ class Dumpzilla():
           conn.create_function("REGEXP", 2, self.regexp)
 
        cursor = conn.cursor()
-       sqlite_query = "select baseDomain, name, value, host, path, datetime(expiry, 'unixepoch', 'localtime'), datetime(lastAccessed/1000000,'unixepoch','localtime') as last ,datetime(creationTime/1000000,'unixepoch','localtime') as creat, isSecure, isHttpOnly FROM moz_cookies"
+       sqlite_query = "select name, value, host, path, datetime(expiry, 'unixepoch', 'localtime'), datetime(lastAccessed/1000000,'unixepoch','localtime') as last ,datetime(creationTime/1000000,'unixepoch','localtime') as creat, isSecure, isHttpOnly FROM moz_cookies"
        self.execute_query(cursor,sqlite_query,self.cookie_filters)
 
        _extraction_list = []
        for row in cursor:
           _extraction_dict = {}
-          _extraction_dict['0-Domain'] = self.decode_reg(row[0])
-          _extraction_dict['1-Host'] = self.decode_reg(row[3])
-          _extraction_dict['2-Name'] = self.decode_reg(row[1])
-          _extraction_dict['3-Value'] = self.decode_reg(row[2])
-          _extraction_dict['4-Path'] = self.decode_reg(row[4])
-          _extraction_dict['5-Expiry'] = self.decode_reg(row[5])
-          _extraction_dict['6-Last Access'] = self.decode_reg(row[6])
-          _extraction_dict['7-Creation Time'] = self.decode_reg(row[7])
+          _extraction_dict['1-Host'] = self.decode_reg(row[2])
+          _extraction_dict['2-Name'] = self.decode_reg(row[0])
+          _extraction_dict['3-Value'] = self.decode_reg(row[1])
+          _extraction_dict['4-Path'] = self.decode_reg(row[3])
+          _extraction_dict['5-Expiry'] = self.decode_reg(row[4])
+          _extraction_dict['6-Last Access'] = self.decode_reg(row[5])
+          _extraction_dict['7-Creation Time'] = self.decode_reg(row[6])
 
-          if self.decode_reg(row[8]) == 0:
+          if self.decode_reg(row[7]) == 0:
              _extraction_dict['8-Secure'] =  'No'
           else:
              _extraction_dict['8-Secure'] =  'Yes'
 
-          if self.decode_reg(row[9]) == 0:
+          if self.decode_reg(row[8]) == 0:
              _extraction_dict['9-HttpOnly'] =  'No'
           else:
              _extraction_dict['9-HttpOnly'] =  'Yes'

--- a/dumpzilla.py
+++ b/dumpzilla.py
@@ -2327,7 +2327,6 @@ Profile location:
                      self.is_dom_ok = True
                  if self.args.domain:
                      cookie_domain = format(self.args.domain[0])
-                     self.cookie_filters.append(["string","baseDomain",cookie_domain])
                      self.domain_filters.append(["string","scope",cookie_domain])
                  if self.args.name:
                      cookie_name = format(self.args.name[0])


### PR DESCRIPTION
This PR removes attempts to access the `baseDomain` column in `moz_cookies` table in `profile_dir/cookies.sqlite`.

I don't know what your contribution policy is, or if you'd rather see it rebased on the `develop` branch, but I think reviewing the "index" values for the updated dictionary. Currently, I just deleted the `0-Domain` entry, leaving the remaining values "as is", but we could also shift everything by 1, resulting in `0-Host`, `1-Name` and so on...).